### PR TITLE
Change default wait timeout for reactions

### DIFF
--- a/.github/actions/comment-reaction-approval/action.yml
+++ b/.github/actions/comment-reaction-approval/action.yml
@@ -17,7 +17,7 @@ inputs:
   wait-timeout-seconds:
     description: 'Time to wait for a reaction in seconds'
     required: false
-    default: '1800'
+    default: '3000'
   check-interval-seconds:
     description: 'Interval between reaction checks'
     required: false


### PR DESCRIPTION
Updated default wait timeout from 1800 to 3000 seconds.